### PR TITLE
Fixes gamerole to avoid params and readRole();

### DIFF
--- a/server/commands/gamerole.js
+++ b/server/commands/gamerole.js
@@ -7,13 +7,16 @@ module.exports = {
 	id: "gamerole",
 	load: () => {},
 	execute: (call) => {
-		var role = call.params.readRole();
-		var game = role.name.toLowerCase();
-		if (games.includes(game)) {
+		var rawinput = call.message.content.substr(10);
+		if (rawinput == undefined) return call.message.reply("You must specify a gamerole!");
+		var game = games.filter(g => g.toLowerCase().startsWith(rawinput.toLowerCase()));
+		if (game.length != games.length && game.length != 0) {
+			game = game[0];
+			var role = call.message.guild.roles.find("name", game);
+			game = role.name.toLowerCase();
 			if(call.message.member.roles.has(role.id)) {
 				call.message.member.removeRole(role).then(() => {
-					call.message.channel
-						.send(`Since you already had the \`${game}\` game role, it has been removed from you!`);
+					call.message.channel.send(`Since you already had the \`${game}\` game role, it has been removed from you!`);
 				}).catch(() => {
 					call.message.channel.send(`Unable to remove the \`${game}\` game role!`);
 				});
@@ -25,8 +28,7 @@ module.exports = {
 				});
 			}
 		} else {
-			call.message.channel
-				.send(`\`${game} \` is not a valid game option.`);
+			call.message.channel.send(`\`${rawinput} \` is not a valid game option.`);
 		}
 	}
 };

--- a/server/commands/gamerole.js
+++ b/server/commands/gamerole.js
@@ -14,7 +14,7 @@ module.exports = {
 			game = game[0];
 			var role = call.message.guild.roles.find("name", game);
 			game = role.name.toLowerCase();
-			if(call.message.member.roles.has(role.id)) {
+			if (call.message.member.roles.has(role.id)) {
 				call.message.member.removeRole(role).then(() => {
 					call.message.channel.send(`Since you already had the \`${game}\` game role, it has been removed from you!`);
 				}).catch(() => {

--- a/server/commands/gamerole.js
+++ b/server/commands/gamerole.js
@@ -7,10 +7,12 @@ module.exports = {
 	id: "gamerole",
 	load: () => {},
 	execute: (call) => {
-		var rawinput = call.message.content.substr(10);
-		if (rawinput == undefined) return call.message.reply("You must specify a gamerole!");
-		var game = games.filter(g => g.toLowerCase().startsWith(rawinput.toLowerCase()));
-		if (game.length != games.length && game.length != 0) {
+		var rawinput = call.params.readRaw();
+		if (rawinput === "") return call.message.reply("You must specify a gamerole!");
+		var game = games.find(function(g) {
+			return g.toLowerCase().startsWith(rawinput.toLowerCase());
+		});
+		if (game !== undefined) {
 			game = game[0];
 			var role = call.message.guild.roles.find("name", game);
 			game = role.name.toLowerCase();


### PR DESCRIPTION
params and readRole(); have been bugging up recently due to changes to parameters.js. In this update I use message.content.substr(6); to exclude the "!gamerole " part of the command. This also allows me to retrieve the full content, which paraams(); was unable to do. Retrieving the full input let gameroles like clash of clans and clash royale (which both have the same first word) both be retrievable.